### PR TITLE
fix: use macos-14-large for Intel builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
             goos: darwin
             goarch: arm64
             suffix: darwin-arm64
-          - os: macos-13
+          - os: macos-14-large
             goos: darwin
             goarch: amd64
             suffix: darwin-amd64


### PR DESCRIPTION
macos-13 runner is deprecated