### PR TITLE
fix: resolve staticcheck lint errors

### DIFF
--- a/internal/chunker/chunker_test.go
+++ b/internal/chunker/chunker_test.go
@@ -558,7 +558,7 @@ func TestChunkerRegistry_RespectsContextCancellation(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // Cancel immediately
 
-	_, err = reg.Chunk(ctx, file)
+	_, _ = reg.Chunk(ctx, file)
 	// Should either return error due to cancelled context or complete
 	// This test ensures no hang occurs with cancelled context
 }

--- a/internal/chunker/csharp_test.go
+++ b/internal/chunker/csharp_test.go
@@ -1355,7 +1355,7 @@ func TestCSharpChunker_CancelledContext(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // Cancel immediately
 
-	_, err = chunker.Chunk(ctx, file)
+	_, _ = chunker.Chunk(ctx, file)
 	// Either returns error or completes - just ensure no hang
 	// The exact behavior depends on implementation
 }

--- a/internal/cli/config_test.go
+++ b/internal/cli/config_test.go
@@ -37,23 +37,6 @@ func newTestProject(t *testing.T) *testProject {
 	}
 }
 
-// newTestProjectWithConfig creates a new temporary project with custom config
-func newTestProjectWithConfig(t *testing.T, cfg *config.Config) *testProject {
-	t.Helper()
-
-	dir := t.TempDir()
-	loader := config.NewLoader(dir)
-
-	err := loader.Save(cfg)
-	require.NoError(t, err)
-
-	return &testProject{
-		Dir:    dir,
-		Config: cfg,
-		Loader: loader,
-	}
-}
-
 // executeConfigCmd executes the config command with given args and returns output
 func executeConfigCmd(t *testing.T, projectDir string, args ...string) (string, string, error) {
 	t.Helper()

--- a/internal/cli/init_test.go
+++ b/internal/cli/init_test.go
@@ -439,7 +439,7 @@ func TestInitCmd_StartFlag_InitializesBeforeStart(t *testing.T) {
 
 	// Run init with --start flag (daemon start will likely fail in test env, but init should complete)
 	var outBuf, errBuf bytes.Buffer
-	err = runInitWithFlags(tmpDir, &outBuf, &errBuf, InitFlags{Start: true})
+	_ = runInitWithFlags(tmpDir, &outBuf, &errBuf, InitFlags{Start: true})
 
 	// Init should succeed even if daemon start fails
 	// The .pommel directory should exist
@@ -459,7 +459,7 @@ func TestInitCmd_StartFlag_CombinesWithOtherFlags(t *testing.T) {
 
 	// Run init with multiple flags
 	var outBuf, errBuf bytes.Buffer
-	err = runInitWithFlags(tmpDir, &outBuf, &errBuf, InitFlags{
+	_ = runInitWithFlags(tmpDir, &outBuf, &errBuf, InitFlags{
 		Auto:   true,
 		Claude: true,
 		Start:  true,

--- a/internal/db/vectors_test.go
+++ b/internal/db/vectors_test.go
@@ -29,15 +29,6 @@ func makeEmbedding(base float32) []float32 {
 	return embedding
 }
 
-// makeSimilarEmbedding creates an embedding similar to the base embedding.
-func makeSimilarEmbedding(base []float32, offset float32) []float32 {
-	embedding := make([]float32, len(base))
-	for i := range embedding {
-		embedding[i] = base[i] + offset
-	}
-	return embedding
-}
-
 // =============================================================================
 // Happy Path / Success Cases
 // =============================================================================


### PR DESCRIPTION
## Summary
- Fixed staticcheck lint errors that were causing CI failures
- Removed unused functions in test files
- Used blank identifier for intentionally unused error returns

## Test plan
- [ ] CI workflow passes (staticcheck no longer reports errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)