### PR TITLE
Fix release workflow - remove cross-compile ARM64 builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,37 +16,32 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # Linux
+          # Linux x64
           - os: ubuntu-latest
             goos: linux
             goarch: amd64
             suffix: linux-amd64
             binary_ext: ""
             archive_ext: tar.gz
-          - os: ubuntu-latest
-            goos: linux
-            goarch: arm64
-            suffix: linux-arm64
+          # macOS Intel (x64)
+          - os: macos-13
+            goos: darwin
+            goarch: amd64
+            suffix: darwin-amd64
             binary_ext: ""
             archive_ext: tar.gz
-          # macOS
+          # macOS Apple Silicon (ARM64)
           - os: macos-latest
             goos: darwin
             goarch: arm64
             suffix: darwin-arm64
             binary_ext: ""
             archive_ext: tar.gz
-          # Windows
+          # Windows x64
           - os: windows-latest
             goos: windows
             goarch: amd64
             suffix: windows-amd64
-            binary_ext: ".exe"
-            archive_ext: zip
-          - os: windows-latest
-            goos: windows
-            goarch: arm64
-            suffix: windows-arm64
             binary_ext: ".exe"
             archive_ext: zip
 

--- a/README.md
+++ b/README.md
@@ -62,9 +62,7 @@ Download binaries from [releases](https://github.com/dbinky/Pommel/releases):
 | macOS | Intel | pm-darwin-amd64 | pommeld-darwin-amd64 |
 | macOS | Apple Silicon | pm-darwin-arm64 | pommeld-darwin-arm64 |
 | Linux | x64 | pm-linux-amd64 | pommeld-linux-amd64 |
-| Linux | ARM64 | pm-linux-arm64 | pommeld-linux-arm64 |
 | Windows | x64 | pm-windows-amd64.exe | pommeld-windows-amd64.exe |
-| Windows | ARM64 | pm-windows-arm64.exe | pommeld-windows-arm64.exe |
 
 Then pull the embedding model:
 ```bash


### PR DESCRIPTION
## Summary
- Removes ARM64 cross-compilation builds that were failing (linux-arm64, windows-arm64)
- Adds darwin-amd64 build using macos-13 runner
- Updates README to reflect actual available binaries

## Problem
The v0.3.0 release failed because CGO cross-compilation for ARM64 on x64 runners doesn't work without a cross-compilation toolchain.

## Solution
Build only on native architectures:
- linux-amd64 on ubuntu-latest
- darwin-amd64 on macos-13 (Intel Mac)
- darwin-arm64 on macos-latest (Apple Silicon)
- windows-amd64 on windows-latest

🤖 Generated with [Claude Code](https://claude.com/claude-code)